### PR TITLE
setuptools 61.2.0+ support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@
 # PEP 518 https://www.python.org/dev/peps/pep-0518/
 # https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821
 requires = [
-#  "setuptools>=61",
-  "setuptools==61.0.0",
+  "setuptools>=61",
   "wheel",               # for bdist package distribution
   "setuptools_scm>=6.4", # for automated versioning
 ]
@@ -28,7 +27,9 @@ write_to = "tinypkg/_version.py"
 # PEP 621 https://peps.python.org/pep-0621/
 [project]
 name = "tinypkg"
-# version = "0.0.1" automated versioning by pypa/setuptools_scm
+# version = "0.0.1"
+# for automated versioning by pypa/setuptools_scm. see https://peps.python.org/pep-0621/#dynamic
+dynamic = ["version"]
 description = "a tiny package example w/setuptools"
 authors = [{ name = "denkiwakame" }, { email = "denkivvakame@gmail.com" }]
 maintainers = [{ name = "denkiwakame" }, { email = "denkivvakame@gmail.com" }]


### PR DESCRIPTION
## ``version'' is mandatory field in [project]
- background: w/setuptools_scm, we will provide `version` dynamically, and should not define static `version` field, which overwrites dynamic versioning.
- [x] specify ``version'' in `dynamic` field https://peps.python.org/pep-0621/#dynamic


## Related
- https://github.com/pypa/setuptools/issues/3199#issuecomment-1079141905